### PR TITLE
fix: fix offcanvas menu to appear at top

### DIFF
--- a/style.css
+++ b/style.css
@@ -127,6 +127,7 @@ nav a:hover::after {
     visibility: hidden;
     will-change: visibility;
     transition: all .2s ease-in;
+    z-index: 99;
 }
 .off-canvas.active {
     transform: translateX(0);


### PR DESCRIPTION
Before, the login form box was popping on top of the off canvas menu but it has been fixed so that the off canvas is always on top